### PR TITLE
Standalone Markdown file support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Pat Migliaccio, and the Contributors.
+Copyright (c) 2018-2019 Pat Migliaccio, and the Contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Provided by default within the application, Notion's "Export -> Print as PDF" fu
 ### Process
 
 ```text
-Markdown Files (ZIP) -> marked -> HTML Files -> wkhtmltoPDF -> PDF Files
+Markdown Files -> marked -> HTML Files -> wkhtmltoPDF -> PDF Files
 ```
 
 The methodology used by this tool is simply to take exported Markdown pages from Notion, individually or in bulk, uncompress the downloaded archive and then process each by first parsing into HTML using [`marked`](https://github.com/markedjs/marked) and then converting to PDF using [`wkhtmltopdf`](https://wkhtmltopdf.org/).
@@ -34,10 +34,17 @@ npm install notion-md-pdf -g
 
 ## Usage
 
-Call the following shell command with the desired zip archive as the first argument.
+Call the following shell command with the desired zip archive of Markdown files as the first argument.
 
 ```bash
 notion-md-pdf Export-XXXXXX.zip
+# Conversion completed: ~/Document-Name-XXXXXX-1.pdf
+```
+
+### Individual Markdown File Support
+
+```bash
+notion-md-pdf Document-Name-XXXXXX.md
 # Conversion completed: ~/Document-Name-XXXXXX-1.pdf
 ```
 

--- a/index.js
+++ b/index.js
@@ -9,29 +9,46 @@ const path = require('path'),
 
 const TEMP_FILE = './temp.html';
 
-let args = process.argv.slice(2);
+function main() {
+  const args = process.argv.slice(2);
 
-let filename = args[0];
+  const filename = args[0];
 
-if (filename === undefined || filename === null) {
-  throw new Error('Missing filename parameter.');
+  if (filename === undefined || filename === null) {
+    throw new Error('Missing filename parameter.');
+  }
+
+  const filePath = path.resolve(filename),
+    fileExt = filename.split('.').pop();
+
+  if (fileExt === 'zip') {
+    const zip = new AdmZip(filePath);
+    const zipEntries = zip.getEntries();
+
+    zipEntries.forEach(zipEntry => {
+      const mdFileName = zipEntry.entryName;
+      const pdfFilePath =
+        path.join(
+          ...[path.dirname(filePath), mdFileName.slice(0, mdFileName.lastIndexOf('.'))]
+        ) + '.pdf';
+
+      const data = zipEntry.getData().toString('utf-8');
+      mdStringtoPDF(data, pdfFilePath);
+    });
+
+  } else if (fileExt === 'md') {
+    const pdfFilePath = filePath.slice(0, filePath.lastIndexOf('.')) + '.pdf';
+
+    const data = fs.readFileSync(filePath, 'utf8')
+    mdStringtoPDF(data, pdfFilePath);
+
+  } else {
+    throw new Error(`File extension (.${fileExt}) is not supported.`)
+  }
+
 }
 
-let zipFilePath = path.resolve(filename);
-
-let zip = new AdmZip(zipFilePath);
-let zipEntries = zip.getEntries();
-
-zipEntries.forEach(zipEntry => {
-  let mdFileName = zipEntry.entryName;
-  let pdfFilePath =
-    path.join(
-      ...[path.dirname(zipFilePath), mdFileName.slice(0, mdFileName.lastIndexOf('.'))]
-    ) + '.pdf';
-
-  let data = zipEntry.getData().toString('utf-8');
-  mdStringtoPDF(data, pdfFilePath);
-});
+main();
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-md-pdf",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Converts pages exported from Notion as Markdown into PDF files using the command line due to browser rendering issues.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Add the ability to convert standalone Markdown (`.md`) files that are not zipped in an archive file (`.zip`)